### PR TITLE
Add ability to provide assertion callback within `can()` and `cannot()` methods

### DIFF
--- a/src/Contracts/WithActions.php
+++ b/src/Contracts/WithActions.php
@@ -94,12 +94,12 @@ interface WithActions
     /**
      * Set whether this task can run (i.e. passes)
      */
-    public function can(bool $can = true): static;
+    public function can(bool|Closure $can = true): static;
 
     /**
      * Set that this task cannot run (i.e. fails)
      */
-    public function cannot(): static;
+    public function cannot(?Closure $cannot = null): static;
 
     /**
      * Get the 'can' / 'cannot' flag for this story

--- a/src/Traits/HasActions.php
+++ b/src/Traits/HasActions.php
@@ -246,8 +246,14 @@ r
     /**
      * Set whether this task can run (i.e. passes)
      */
-    public function can(bool $can = true): static
+    public function can(bool|Closure $can = true): static
     {
+        if ($can instanceof Closure) {
+            $this->setCallback('can', $can);
+
+            $can = true;
+        }
+
         $this->can = $can;
 
         return $this;
@@ -256,8 +262,12 @@ r
     /**
      * Set that this task cannot run (i.e. fails)
      */
-    public function cannot(): static
+    public function cannot(?Closure $cannot = null): static
     {
+        if ($cannot instanceof Closure) {
+            $this->setCallback('cannot', $cannot);
+        }
+
         return $this->can(false);
     }
 

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -424,3 +424,21 @@ test('can fetch all registered actions', function () {
             'c',
         ]);
 });
+
+test('you can specify the assertion callbacks via the expectation can/cannot methods', function () {
+    $ran = Collection::make();
+
+    Story::make('parent')
+        ->action(fn () => null)
+        ->stories([
+            Story::make('child can')->can(fn () => $ran[] = 'can'),
+            Story::make('child cannot')->cannot(fn () => $ran[] = 'cannot'),
+        ])
+        ->storiesAll
+        ->each(fn (Story $story) => $story->run());
+
+    expect($ran->all())->toBe([
+        'can',
+        'cannot',
+    ]);
+});


### PR DESCRIPTION
Closes https://github.com/bradietilley/pest-storyboard/issues/5

Add ability to go:

```php
Story::make()->can(fn () => doSomething());

// same as

Story::make()->can()->assert(fn () => doSomething());
```

...

- [x] I have read the **[CONTRIBUTING](https://github.com/bradietilley/pest-storyboard/blob/main/.github/CONTRIBUTING.md)** document.
