### PR TITLE
Aadd invokable callbacks

### DIFF
--- a/src/Callback.php
+++ b/src/Callback.php
@@ -390,7 +390,7 @@ abstract class Callback
     }
 
     /**
-     * Give this instance a random name
+     * Get a random name for this instance
      */
     public static function getRandomName(): string
     {

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BradieTilley\Stories;
 
+use BradieTilley\Stories\Contracts\InvokableCallback;
 use BradieTilley\Stories\Helpers\CallbackRepository;
 use BradieTilley\Stories\Helpers\StoryAliases;
 use BradieTilley\Stories\Traits\HasSequences;
@@ -34,10 +35,21 @@ abstract class Callback
     /** Time limit controller */
     protected ?Alarm $alarm = null;
 
-    public function __construct(protected string $name, protected ?Closure $callback = null, array $arguments = [])
+    /** The name of the callback */
+    protected string $name;
+
+    /** The Primary callback */
+    protected ?Closure $callback = null;
+
+    public function __construct(string $name = null, ?Closure $callback = null, array $arguments = [])
     {
-        $this->variable = $name;
-        $this->with($arguments)->store();
+        $name ??= static::getRandomName();
+
+        $this->setName($name)
+            ->as($callback)
+            ->for($name)
+            ->with($arguments)
+            ->store();
     }
 
     /**
@@ -77,7 +89,7 @@ abstract class Callback
             return static::fetch($item);
         }
 
-        return static::make(Str::random(8), $item);
+        return static::make()->as($item);
     }
 
     /**
@@ -122,15 +134,26 @@ abstract class Callback
             'action' => Action::class,
             'assertion' => Assertion::class,
             'story' => Story::class,
-            default => static::class,
+            default => null,
         };
 
-        $class = StoryAliases::getClassAlias($class);
+        /**
+         * Use aliased classes when calling `::make()` on any
+         * base-level callback classes like Action, Assertion
+         * or Story. If a custom child class is referenced in
+         * a ::make() call then use the static class directly
+         */
+        if ($class === static::class) {
+            $class = StoryAliases::getClassAlias($class);
 
-        /** @var static $callback */
-        $callback = new $class(...func_get_args());
+            /** @var static $callback */
+            $callback = new $class(...func_get_args());
 
-        return $callback;
+            return $callback;
+        }
+
+        /** @phpstan-ignore-next-line */
+        return new static(...func_get_args());
     }
 
     /**
@@ -255,6 +278,12 @@ abstract class Callback
             );
         }
 
+        if ($this instanceof InvokableCallback) {
+            $allArguments = $this->getInternalCallArguments($arguments);
+
+            $arguments['result'] = Container::getInstance()->call([$this, '__invoke'], $allArguments);
+        }
+
         return $arguments['result'];
     }
 
@@ -358,5 +387,13 @@ abstract class Callback
     public function alarm(): ?Alarm
     {
         return $this->alarm;
+    }
+
+    /**
+     * Give this instance a random name
+     */
+    public static function getRandomName(): string
+    {
+        return static::class.'@'.Str::random(8);
     }
 }

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -13,7 +13,7 @@ use Illuminate\Container\Container;
 use Illuminate\Support\Str;
 
 /**
- * @method static static make(string $name = '', Closure $callback, array $arguments = [])
+ * @method static static make(string $name = null, Closure $callback, array $arguments = [])
  */
 abstract class Callback
 {

--- a/src/Contracts/InvokableCallback.php
+++ b/src/Contracts/InvokableCallback.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BradieTilley\Stories\Contracts;
+
+/**
+ * @method mixed __invoke() Dependency-Injection available
+ */
+interface InvokableCallback
+{
+}

--- a/src/Helpers/functions.php
+++ b/src/Helpers/functions.php
@@ -16,7 +16,7 @@ use Closure;
 /**
  * Create a new story
  */
-function story(string $name = '', Closure|callable|null $callback = null): Story
+function story(string $name = '', ?Closure $callback = null): Story
 {
     return Story::make($name, $callback);
 }
@@ -24,7 +24,7 @@ function story(string $name = '', Closure|callable|null $callback = null): Story
 /**
  * Create a new assertion
  */
-function assertion(string $name = '', Closure|callable|null $callback = null): Assertion
+function assertion(string $name = null, ?Closure $callback = null): Assertion
 {
     return Assertion::make($name, $callback);
 }
@@ -32,7 +32,7 @@ function assertion(string $name = '', Closure|callable|null $callback = null): A
 /**
  * Create a new action
  */
-function action(string $name = '', Closure|callable|null $callback = null): Action
+function action(string $name = null, ?Closure $callback = null): Action
 {
     return Action::make($name, $callback);
 }

--- a/src/Story.php
+++ b/src/Story.php
@@ -20,6 +20,9 @@ use Pest\TestSuite;
 use PHPUnit\Framework\TestCase;
 use Tests\Mocks\PestStoriesMockTestCall;
 
+/**
+ * @method static static make(string $name = '', ?Closure $callback = null, array $arguments = [])
+ */
 class Story extends Callback
 {
     use Conditionable;

--- a/src/Story.php
+++ b/src/Story.php
@@ -49,7 +49,7 @@ class Story extends Callback
 
     protected ExpectationChain $expectations;
 
-    public function __construct(protected string $name, protected ?Closure $callback = null, array $arguments = [])
+    public function __construct(string $name = '', ?Closure $callback = null, array $arguments = [])
     {
         parent::__construct($name, $callback, $arguments);
 

--- a/src/Story.php
+++ b/src/Story.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BradieTilley\Stories;
 
+use BradieTilley\Stories\Contracts\InvokableCallback;
 use BradieTilley\Stories\Exceptions\FunctionAliasNotFoundException;
 use BradieTilley\Stories\Exceptions\TestCaseUnavailableException;
 use BradieTilley\Stories\Helpers\StoryAliases;
@@ -129,6 +130,15 @@ class Story extends Callback
                 $actionItem->for($for);
             }
 
+            /**
+             * Invokable actions may not be stored in the repostory yet so
+             * record the callback so that we can reference the callback by
+             * its name.
+             */
+            if ($actionItem instanceof InvokableCallback) {
+                $actionItem->store();
+            }
+
             $this->actions[] = [
                 'name' => $actionItem->getName(),
                 'arguments' => $arguments,
@@ -163,6 +173,15 @@ class Story extends Callback
         );
 
         foreach ($assertion as $assertionItem) {
+            /**
+             * Invokable assertions may not be stored in the repostory yet
+             * so record the callback so that we can reference the callback
+             * by its name.
+             */
+            if ($assertionItem instanceof InvokableCallback) {
+                $assertionItem->store();
+            }
+
             $this->assertions[] = [
                 'name' => $assertionItem->getName(),
                 'arguments' => $arguments,

--- a/tests/Mocks/MockInvokableAction.php
+++ b/tests/Mocks/MockInvokableAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Mocks;
+
+use BradieTilley\Stories\Action;
+use BradieTilley\Stories\Contracts\InvokableCallback;
+use BradieTilley\Stories\Story;
+
+class MockInvokableAction extends Action implements InvokableCallback
+{
+    protected string $string = '';
+
+    protected int $integer = 0;
+
+    public static array $invoked = [];
+
+    public function __invoke(Story $story, string $a, int $b): float
+    {
+        self::$invoked[] = [
+            'story' => $story,
+            'a' => $a,
+            'b' => $b,
+            'string' => $this->string,
+            'integer' => $this->integer,
+        ];
+
+        return 0.1;
+    }
+
+    public function withString(string $value): self
+    {
+        $this->string = $value;
+
+        return $this;
+    }
+
+    public function withInteger(int $value): self
+    {
+        $this->integer = $value;
+
+        return $this;
+    }
+}

--- a/tests/Mocks/MockInvokableAssertion.php
+++ b/tests/Mocks/MockInvokableAssertion.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Mocks;
+
+use BradieTilley\Stories\Assertion;
+use BradieTilley\Stories\Contracts\InvokableCallback;
+use BradieTilley\Stories\Story;
+
+class MockInvokableAssertion extends Assertion implements InvokableCallback
+{
+    protected string $string = '';
+
+    protected int $integer = 0;
+
+    public static array $invoked = [];
+
+    public function __invoke(Story $story, string $a, int $b): float
+    {
+        self::$invoked[] = [
+            'story' => $story,
+            'a' => $a,
+            'b' => $b,
+            'string' => $this->string,
+            'integer' => $this->integer,
+        ];
+
+        return 0.1;
+    }
+
+    public function withString(string $value): self
+    {
+        $this->string = $value;
+
+        return $this;
+    }
+
+    public function withInteger(int $value): self
+    {
+        $this->integer = $value;
+
+        return $this;
+    }
+}

--- a/tests/Unit/InvokableCallbackTest.php
+++ b/tests/Unit/InvokableCallbackTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use function BradieTilley\Stories\Helpers\story;
+use Tests\Mocks\MockInvokableAction;
+use Tests\Mocks\MockInvokableAssertion;
+
+test('an invokable callback class can be stored multiple times', function () {
+    $foo = MockInvokableAction::make()->withString('Foo')->withInteger(12);
+    $bar = MockInvokableAction::make()->withString('Bar')->withInteger(34);
+    $baz = MockInvokableAssertion::make()->withString('Baz')->withInteger(56);
+    $qux = MockInvokableAssertion::make()->withString('Qux')->withInteger(78);
+
+    ($story = story('a story with the sample action with different instances'))
+        ->with([
+            'a' => 'Testing',
+            'b' => 111,
+        ])
+        ->action($foo)
+        ->action($bar)
+        ->assertion($baz)
+        ->assertion($qux)
+        ->process();
+
+    expect(MockInvokableAction::$invoked)->ToBe([
+        [
+            'story' => $story,
+            'a' => 'Testing',
+            'b' => 111,
+            'string' => 'Foo',
+            'integer' => 12,
+        ],
+        [
+            'story' => $story,
+            'a' => 'Testing',
+            'b' => 111,
+            'string' => 'Bar',
+            'integer' => 34,
+        ],
+    ]);
+
+    expect(MockInvokableAssertion::$invoked)->ToBe([
+        [
+            'story' => $story,
+            'a' => 'Testing',
+            'b' => 111,
+            'string' => 'Baz',
+            'integer' => 56,
+        ],
+        [
+            'story' => $story,
+            'a' => 'Testing',
+            'b' => 111,
+            'string' => 'Qux',
+            'integer' => 78,
+        ],
+    ]);
+});


### PR DESCRIPTION
Closes https://github.com/bradietilley/pest-stories/issues/52

- Adds: Ability to create custom callback classes in an easier way using the `InvokableCallback` interface.
- Changes: The property promotion in abstract callback and Story is refactored as properties + setters for cleaner inheritance.
- Changes: Random names for callbacks (including inline closures that get converted) is now the static class name followed by `@` followed by 8 random characters.
